### PR TITLE
py_stringsimjoin 0.3.5 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/py_stringmatching-feedstock/pr1/df03c5d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/py_stringmatching-feedstock/pr1/df03c5d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,14 +36,7 @@ requirements:
     - py_stringmatching >=0.2.1
 
 {% set tests_to_ignore = "\"" %}
-# test_valid_join is called three times and results in, inter alia:
-# E       fixture 'scenario' not found
-# >       available fixtures: cache, capfd, capfdbinary, caplog,
-#           capsys, capsysbinary, doctest_namespace, monkeypatch,
-#           pytestconfig, record_property, record_testsuite_property,
-#           record_xml_attribute, recwarn, tmp_path, tmp_path_factory,
-#           tmpdir, tmpdir_factory
-# >       use 'pytest --fixtures [testpath]' for help on them.
+# skip test_valid_join (in 3 test files), marked @unittest.skip("Not a test")
 {% set tests_to_ignore = tests_to_ignore + "not test_valid_join " %}
 {% set tests_to_ignore = tests_to_ignore + "\"" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - pyprind >=2.9.3
     - py_stringmatching >=0.2.1
 
-{% set tests_to_ignore = "'" %}
+{% set tests_to_ignore = "\"" %}
 # test_valid_join is called three times and results in, inter alia:
 # E       fixture 'scenario' not found
 # >       available fixtures: cache, capfd, capfdbinary, caplog,
@@ -50,7 +50,7 @@ requirements:
 #           tmpdir, tmpdir_factory
 # >       use 'pytest --fixtures [testpath]' for help on them.
 {% set tests_to_ignore = tests_to_ignore + "not test_valid_join " %}
-{% set tests_to_ignore = tests_to_ignore + "'" %}
+{% set tests_to_ignore = tests_to_ignore + "\"" %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,16 @@
 {% set name = "py_stringsimjoin" %}
-{% set version = "0.3.2" %}
-{% set sha256 = "a41aa3d0b3520333b7a38132fd1e6f5f9b3421be64f964e644ff7544cacbc89b" %}
+{% set version = "0.3.5" %}
+{% set sha256 = "e8b5a805c991ceb7d72ecefb3d20808dd25bdb0efac14ac415c74cad56b52ce4" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  # Using the GH archive as it contains the .pxd (and not the .cpp)
+  # files required for Cython
+  url: https://github.com/anhaidgroup/py_stringsimjoin/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 9a129b6ba1f5670164c13ac0bac4bab50eb0b6080080f22a225d17ff6721887e
 
 build:
   number: 0
@@ -47,7 +49,7 @@ test:
     - pip check
 
 about:
-  home: https://sites.google.com/site/anhaidgroup/projects/py_stringsimjoin
+  home: https://sites.google.com/site/anhaidgroup/current-projects/magellan/py_stringsimjoin
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -57,7 +59,7 @@ about:
     scalable implementation of string similarity joins over two tables,
     for commonly used similarity measures such as Jaccard, Dice, cosine,
     overlap, overlap coefficient and edit distance. 
-  doc_url: http://anhaidgroup.github.io/py_stringsimjoin/
+  doc_url: https://anhaidgroup.github.io/py_stringsimjoin/
   dev_url: https://github.com/anhaidgroup/py_stringsimjoin
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,13 +40,29 @@ requirements:
     - pyprind >=2.9.3
     - py_stringmatching >=0.2.1
 
+{% set tests_to_ignore = "'" %}
+# test_valid_join is called three times and results in, inter alia:
+# E       fixture 'scenario' not found
+# >       available fixtures: cache, capfd, capfdbinary, caplog,
+#           capsys, capsysbinary, doctest_namespace, monkeypatch,
+#           pytestconfig, record_property, record_testsuite_property,
+#           record_xml_attribute, recwarn, tmp_path, tmp_path_factory,
+#           tmpdir, tmpdir_factory
+# >       use 'pytest --fixtures [testpath]' for help on them.
+{% set tests_to_ignore = tests_to_ignore + "not test_valid_join " %}
+{% set tests_to_ignore = tests_to_ignore + "'" %}
+
 test:
+  source_files:
+    - py_stringsimjoin/tests
   imports:
     - py_stringsimjoin
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v py_stringsimjoin/tests -k {{ tests_to_ignore }}
 
 about:
   home: https://sites.google.com/site/anhaidgroup/current-projects/magellan/py_stringsimjoin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,11 +27,6 @@ requirements:
     - setuptools
     - wheel
     - cython
-    - pandas >=0.16.0
-    - six
-    - joblib
-    - pyprind >=2.9.3
-    - py_stringmatching >=0.2.1
   run:
     - python
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,5 +76,3 @@ about:
 extra:
   recipe-maintainers:
     - pjmartinkus
-  skip-lints:
-    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
+{% set name = "py_stringsimjoin" %}
 {% set version = "0.3.2" %}
 {% set sha256 = "a41aa3d0b3520333b7a38132fd1e6f5f9b3421be64f964e644ff7544cacbc89b" %}
 
 package:
-  name: py_stringsimjoin
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/py_stringsimjoin/py_stringsimjoin-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [not x86_64]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -23,12 +23,13 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
     - cython
-    - pandas
+    - pandas >=0.16.0
     - six
     - joblib
-    - pyprind
-    - py_stringmatching
+    - pyprind >=2.9.3
+    - py_stringmatching >=0.2.1
   run:
     - python
     - six
@@ -40,6 +41,10 @@ requirements:
 test:
   imports:
     - py_stringsimjoin
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://sites.google.com/site/anhaidgroup/projects/py_stringsimjoin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,3 +81,5 @@ about:
 extra:
   recipe-maintainers:
     - pjmartinkus
+  skip-lints:
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
py_stringsimjoin 0.3.5 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5064]
- dev_url:        https://github.com/anhaidgroup/py_stringsimjoin/tree/v0.3.5
- conda_forge:    https://github.com/conda-forge/py_stringsimjoin-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/py_stringsimjoin/0.3.5
- pypi inspector: https://inspector.pypi.io/project/py_stringsimjoin/0.3.5

### Explanation of changes:

- basic build (NB linter complains about exact pinnings)
   - using the GH archive as it contains the `.pxd` files necessary for `cython` (and doesn't contains the `.cpp` files in the pypi tarball)
- add (most) upstream tests
- reduce `requirements.host` entries to those required for build


[PKG-5064]: https://anaconda.atlassian.net/browse/PKG-5064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ